### PR TITLE
feat: User 엔티티 및 CRUD 기본 구조 구현

### DIFF
--- a/src/main/java/com/gdg/slbackend/api/user/UserController.java
+++ b/src/main/java/com/gdg/slbackend/api/user/UserController.java
@@ -1,0 +1,36 @@
+package com.gdg.slbackend.api.user;
+
+import com.gdg.slbackend.api.user.dto.UserResponse;
+import com.gdg.slbackend.global.response.ApiResponse;
+import com.gdg.slbackend.service.user.UserService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    /**
+     * User 도메인 관련 단일 조회 및 업데이트 기능을 담당함.
+     * 로그인 정보 조회(/auth/me) 기능은 AuthController에서 구현 예정임.
+     */
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/{userId}")
+    public ApiResponse<UserResponse> getUser(@PathVariable Long userId) {
+        return ApiResponse.success(userService.getUserById(userId));
+    }
+
+    @PostMapping("/me/nickname")
+    public ApiResponse<Void> updateNickname(
+            @RequestParam Long userId,
+            @RequestParam String nickname
+    ) {
+        userService.updateNickname(userId, nickname);
+        return ApiResponse.success();
+    }
+}

--- a/src/main/java/com/gdg/slbackend/api/user/dto/UserResponse.java
+++ b/src/main/java/com/gdg/slbackend/api/user/dto/UserResponse.java
@@ -1,0 +1,40 @@
+package com.gdg.slbackend.api.user.dto;
+
+import com.gdg.slbackend.domain.user.User;
+
+public class UserResponse {
+
+    private Long id;
+    private String email;
+    private String displayName;
+    private String nickname;
+    private String role;
+
+    public UserResponse(User user) {
+        this.id = user.getId();
+        this.email = user.getEmail();
+        this.displayName = user.getDisplayName();
+        this.nickname = user.getNickname();
+        this.role = user.getRole().name();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public String getRole() {
+        return role;
+    }
+}

--- a/src/main/java/com/gdg/slbackend/domain/user/User.java
+++ b/src/main/java/com/gdg/slbackend/domain/user/User.java
@@ -1,0 +1,101 @@
+package com.gdg.slbackend.domain.user;
+
+import com.gdg.slbackend.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "users")
+public class User extends BaseTimeEntity {
+
+    /**
+     * MS OAuth 사용자 정보를 저장하는 엔티티임.
+     * 서비스 전역의 계정 역할을 담당하며,
+     * 커뮤니티별 권한은 CommunityMembership에서 관리함.
+     */
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String oauthProvider; // "MICROSOFT"
+
+    @Column(nullable = false, unique = true)
+    private String oauthSubject; // MS의 sub/oid
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String displayName;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role;
+
+    @Column
+    private String lastLoginAt;
+
+    protected User() {
+        // JPA 기본 생성자
+    }
+
+    public User(
+            String oauthProvider,
+            String oauthSubject,
+            String email,
+            String displayName,
+            String nickname,
+            UserRole role
+    ) {
+        this.oauthProvider = oauthProvider;
+        this.oauthSubject = oauthSubject;
+        this.email = email;
+        this.displayName = displayName;
+        this.nickname = nickname;
+        this.role = role;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getOauthProvider() {
+        return oauthProvider;
+    }
+
+    public String getOauthSubject() {
+        return oauthSubject;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public UserRole getRole() {
+        return role;
+    }
+
+    public String getLastLoginAt() {
+        return lastLoginAt;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateLastLoginAt(String time) {
+        this.lastLoginAt = time;
+    }
+}

--- a/src/main/java/com/gdg/slbackend/domain/user/UserRepository.java
+++ b/src/main/java/com/gdg/slbackend/domain/user/UserRepository.java
@@ -1,0 +1,11 @@
+package com.gdg.slbackend.domain.user;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByOauthSubject(String oauthSubject);
+
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/gdg/slbackend/domain/user/UserRole.java
+++ b/src/main/java/com/gdg/slbackend/domain/user/UserRole.java
@@ -1,0 +1,6 @@
+package com.gdg.slbackend.domain.user;
+
+public enum UserRole {
+    SYSTEM_ADMIN,
+    USER
+}

--- a/src/main/java/com/gdg/slbackend/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/gdg/slbackend/global/entity/BaseTimeEntity.java
@@ -1,12 +1,14 @@
 package com.gdg.slbackend.global.entity;
 
-import java.time.LocalDateTime;
-import javax.persistence.Column;
-import javax.persistence.EntityListeners;
-import javax.persistence.MappedSuperclass;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
 
 /**
  * 모든 엔티티에 공통으로 적용되는 생성/수정 시간 필드를 제공함.

--- a/src/main/java/com/gdg/slbackend/service/user/UserService.java
+++ b/src/main/java/com/gdg/slbackend/service/user/UserService.java
@@ -1,0 +1,42 @@
+package com.gdg.slbackend.service.user;
+
+import com.gdg.slbackend.api.user.dto.UserResponse;
+import com.gdg.slbackend.domain.user.User;
+import com.gdg.slbackend.domain.user.UserRepository;
+import com.gdg.slbackend.global.exception.ErrorCode;
+import com.gdg.slbackend.global.exception.GlobalException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public UserResponse getUserById(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+
+        return new UserResponse(user);
+    }
+
+    @Transactional
+    public void updateNickname(Long userId, String nickname) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+
+        user.updateNickname(nickname);
+    }
+
+    public UserResponse findByEmail(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+
+        return new UserResponse(user);
+    }
+}


### PR DESCRIPTION
User 도메인의 초기 구조 및 핵심 기능을 구현했습니다.

### 주요 변경 사항
- User 엔티티 생성 (MS OAuth 사용자 정보 기반)
- UserRole Enum 추가
- UserRepository 생성 (email, oauthSubject 조회 기능 포함)
- UserResponse DTO 추가
- UserService 기본 CRUD 및 닉네임 수정 기능 구현
- UserController 생성 (단일 조회, 닉네임 변경 API 제공)

###  구성된 파일
- domain/user/User.java
- domain/user/UserRole.java
- domain/user/UserRepository.java
- service/user/UserService.java
- api/user/UserController.java
- api/user/dto/UserResponse.java

###  구현 목적
- 이후 OAuth2(MS 로그인) Flow에서 User 정보를 저장하기 위한 기반 마련
- 커뮤니티/멤버십 기능과 연동할 수 있도록 사용자 모델 완성
- `/auth/me` 등 인증 API 개발 시 활용 가능하도록 User 조회 구조 확립

###  이후 예정 작업
- MS OAuth + JWT 기반 인증 처리
- Community / CommunityMembership 도메인 구현
- UserContext / @AuthUser 적용

