### PR TITLE
feat: 신고(Report) 도메인 및 게시글/댓글 신고 API 구현

### DIFF
--- a/src/main/java/com/gdg/slbackend/api/report/ReportController.java
+++ b/src/main/java/com/gdg/slbackend/api/report/ReportController.java
@@ -1,0 +1,42 @@
+package com.gdg.slbackend.api.report;
+
+import com.gdg.slbackend.global.response.ApiResponse;
+import com.gdg.slbackend.global.security.UserPrincipal;
+import com.gdg.slbackend.service.report.ReportService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/reports")
+public class ReportController {
+
+    private final ReportService service;
+
+    public ReportController(ReportService service) {
+        this.service = service;
+    }
+
+    // 게시글 신고
+    @PostMapping("/posts/{postId}")
+    public ApiResponse<Void> reportPost(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long postId,
+            @RequestParam Long reportedUserId,
+            @RequestParam(required = false) String reason
+    ) {
+        service.reportPost(principal.getId(), reportedUserId, postId, reason);
+        return ApiResponse.success();
+    }
+
+    // 댓글 신고
+    @PostMapping("/comments/{commentId}")
+    public ApiResponse<Void> reportComment(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable Long commentId,
+            @RequestParam Long reportedUserId,
+            @RequestParam(required = false) String reason
+    ) {
+        service.reportComment(principal.getId(), reportedUserId, commentId, reason);
+        return ApiResponse.success();
+    }
+}

--- a/src/main/java/com/gdg/slbackend/domain/report/Report.java
+++ b/src/main/java/com/gdg/slbackend/domain/report/Report.java
@@ -1,0 +1,56 @@
+package com.gdg.slbackend.domain.report;
+
+import com.gdg.slbackend.domain.user.User;
+import com.gdg.slbackend.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "reports")
+public class Report extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 신고한 사람
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private User reporter;
+
+    // 신고 당한 사람
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reported_user_id", nullable = false)
+    private User reportedUser;
+
+    @Column
+    private Long postId;
+
+    @Column
+    private Long commentId;
+
+    @Column
+    private String reason;
+
+    protected Report() {}
+
+    public Report(
+            User reporter,
+            User reportedUser,
+            Long postId,
+            Long commentId,
+            String reason
+    ) {
+        this.reporter = reporter;
+        this.reportedUser = reportedUser;
+        this.postId = postId;
+        this.commentId = commentId;
+        this.reason = reason;
+    }
+
+    public Long getId() { return id; }
+    public User getReporter() { return reporter; }
+    public User getReportedUser() { return reportedUser; }
+    public Long getPostId() { return postId; }
+    public Long getCommentId() { return commentId; }
+    public String getReason() { return reason; }
+}

--- a/src/main/java/com/gdg/slbackend/domain/report/ReportRepository.java
+++ b/src/main/java/com/gdg/slbackend/domain/report/ReportRepository.java
@@ -1,0 +1,8 @@
+package com.gdg.slbackend.domain.report;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    long countByReportedUserId(Long reportedUserId);
+}

--- a/src/main/java/com/gdg/slbackend/service/auth/AuthService.java
+++ b/src/main/java/com/gdg/slbackend/service/auth/AuthService.java
@@ -82,7 +82,7 @@ public class AuthService {
             User user = userRepository.findById(Long.parseLong(claims.getSubject()))
                     .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
 
-            if (user.isBANNED()) {
+            if (user.isBanned()) {
                 throw new GlobalException(ErrorCode.USER_BANNED);
             }
 

--- a/src/main/java/com/gdg/slbackend/service/report/ReportService.java
+++ b/src/main/java/com/gdg/slbackend/service/report/ReportService.java
@@ -1,0 +1,62 @@
+package com.gdg.slbackend.service.report;
+
+import com.gdg.slbackend.domain.report.Report;
+import com.gdg.slbackend.domain.report.ReportRepository;
+import com.gdg.slbackend.domain.user.User;
+import com.gdg.slbackend.domain.user.UserRepository;
+import com.gdg.slbackend.global.exception.ErrorCode;
+import com.gdg.slbackend.global.exception.GlobalException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final UserRepository userRepository;
+
+    public ReportService(
+            ReportRepository reportRepository,
+            UserRepository userRepository
+    ) {
+        this.reportRepository = reportRepository;
+        this.userRepository = userRepository;
+    }
+
+    public void reportPost(Long reporterId, Long reportedUserId, Long postId, String reason) {
+        createReport(reporterId, reportedUserId, postId, null, reason);
+    }
+
+    public void reportComment(Long reporterId, Long reportedUserId, Long commentId, String reason) {
+        createReport(reporterId, reportedUserId, null, commentId, reason);
+    }
+
+    private void createReport(
+            Long reporterId,
+            Long reportedUserId,
+            Long postId,
+            Long commentId,
+            String reason
+    ) {
+        if ((postId == null && commentId == null) || (postId != null && commentId != null)) {
+            throw new GlobalException(ErrorCode.INVALID_REPORT_TARGET);
+        }
+
+        User reporter = userRepository.findById(reporterId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+
+        User reportedUser = userRepository.findById(reportedUserId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+
+        Report report = new Report(reporter, reportedUser, postId, commentId, reason);
+        reportRepository.save(report);
+
+        long count = reportRepository.countByReportedUserId(reportedUserId);
+
+        // 5회 이상 신고 누적 → 영구 정지
+        if (count >= 5) {
+            reportedUser.ban();
+        }
+    }
+}


### PR DESCRIPTION
신고(Report) 도메인과 게시글·댓글 신고 API를 구현했습니다.

## 주요 변경 사항
- Report 엔티티 생성
  - reporter / reportedUser (User 연관관계)
  - postId, commentId 신고 대상 저장
  - BaseTimeEntity 기반 생성/수정 시간 관리
- ReportRepository 생성
  - 신고 대상 사용자별 누적 신고 수 조회 기능 제공
- ReportService 구현
  - 게시글 신고 처리
  - 댓글 신고 처리
  - 신고 유효성 검사 (postId/commentId 중 하나만 허용)
  - 누적 신고 5회 시 자동 계정 Ban
- ReportController 구현
  - /reports/posts/{postId}
  - /reports/comments/{commentId}

## 구성된 파일
- domain/report/Report.java
- domain/report/ReportRepository.java
- service/report/ReportService.java
- api/report/ReportController.java

## 구현 목적
- 서비스 내 악성 사용자 제재 기능 구축
- 신고 누적 기반 자동 정지 로직 적용
- 게시글/댓글 도메인 개발 전 단계에서도 테스트 가능한 구조 확보
