### PR TITLE
feat: Springdoc OpenAPI 설정 및 Swagger 태그 추가

### DIFF
--- a/src/main/java/com/gdg/slbackend/api/auth/AuthController.java
+++ b/src/main/java/com/gdg/slbackend/api/auth/AuthController.java
@@ -7,6 +7,8 @@ import com.gdg.slbackend.global.response.ApiResponse;
 import com.gdg.slbackend.global.security.UserPrincipal;
 import com.gdg.slbackend.service.auth.AuthService;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/auth")
+@Tag(name = "Auth", description = "인증/인가 관련 API")
 public class AuthController {
 
     private final AuthService authService;
@@ -27,6 +30,7 @@ public class AuthController {
     }
 
     @GetMapping("/login")
+    @Operation(summary = "마이크로소프트 로그인 리다이렉트")
     public ResponseEntity<Void> loginRedirect() {
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.LOCATION, "/oauth2/authorization/microsoft");
@@ -34,11 +38,13 @@ public class AuthController {
     }
 
     @GetMapping("/me")
+    @Operation(summary = "내 프로필 조회")
     public ApiResponse<UserResponse> me(@AuthenticationPrincipal UserPrincipal principal) {
         return ApiResponse.success(authService.toUserResponse(principal));
     }
 
     @PostMapping("/refresh")
+    @Operation(summary = "토큰 재발급")
     public ApiResponse<AuthTokenResponse> refresh(@Valid @RequestBody RefreshTokenRequest request) {
         return ApiResponse.success(authService.refreshTokens(request.getRefreshToken()));
     }

--- a/src/main/java/com/gdg/slbackend/api/report/ReportController.java
+++ b/src/main/java/com/gdg/slbackend/api/report/ReportController.java
@@ -3,11 +3,14 @@ package com.gdg.slbackend.api.report;
 import com.gdg.slbackend.global.response.ApiResponse;
 import com.gdg.slbackend.global.security.UserPrincipal;
 import com.gdg.slbackend.service.report.ReportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/reports")
+@Tag(name = "Report", description = "게시글 및 댓글 신고 API")
 public class ReportController {
 
     private final ReportService service;
@@ -18,6 +21,7 @@ public class ReportController {
 
     // 게시글 신고
     @PostMapping("/posts/{postId}")
+    @Operation(summary = "게시글 신고")
     public ApiResponse<Void> reportPost(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long postId,
@@ -30,6 +34,7 @@ public class ReportController {
 
     // 댓글 신고
     @PostMapping("/comments/{commentId}")
+    @Operation(summary = "댓글 신고")
     public ApiResponse<Void> reportComment(
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long commentId,

--- a/src/main/java/com/gdg/slbackend/api/user/UserController.java
+++ b/src/main/java/com/gdg/slbackend/api/user/UserController.java
@@ -5,11 +5,14 @@ import com.gdg.slbackend.api.user.dto.UserResponse;
 import com.gdg.slbackend.global.response.ApiResponse;
 import com.gdg.slbackend.global.security.UserPrincipal;
 import com.gdg.slbackend.service.user.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/users")
+@Tag(name = "User", description = "사용자 조회 및 마일리지 관리 API")
 public class UserController {
 
     /**
@@ -24,11 +27,13 @@ public class UserController {
     }
 
     @GetMapping("/{userId}")
+    @Operation(summary = "사용자 단건 조회")
     public ApiResponse<UserResponse> getUser(@PathVariable Long userId) {
         return ApiResponse.success(userService.getUserById(userId));
     }
 
     @PostMapping("/me/nickname")
+    @Operation(summary = "닉네임 변경")
     public ApiResponse<Void> updateNickname(
             @RequestParam Long userId,
             @AuthenticationPrincipal com.gdg.slbackend.global.security.UserPrincipal principal,
@@ -42,6 +47,7 @@ public class UserController {
      * 현재 로그인한 사용자의 마일리지를 조회함.
      */
     @GetMapping("/me/mileage")
+    @Operation(summary = "내 마일리지 조회")
     public ApiResponse<UserMileageResponse> getMyMileage(
             @AuthenticationPrincipal UserPrincipal principal
     ) {
@@ -54,6 +60,7 @@ public class UserController {
      * amount 만큼 차감하며, 부족할 경우 예외가 발생함.
      */
     @PostMapping("/me/mileage/use")
+    @Operation(summary = "내 마일리지 사용")
     public ApiResponse<UserMileageResponse> useMyMileage(
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestParam int amount


### PR DESCRIPTION
Springdoc OpenAPI 기반 Swagger 문서를 추가하고 주요 컨트롤러에 태그/요약 정보를 설정했습니다.

## 주요 변경 사항
- Springdoc OpenAPI 의존성 추가
  - build.gradle에 `springdoc-openapi-starter-webmvc-ui:2.6.0` 의존성 추가
  - `/swagger-ui.html`을 통해 브라우저에서 API 문서 확인 가능
- OpenApiConfig 생성
  - 서비스 메타데이터(title, version, description, contact) 설정
  - 로컬/배포 환경에 대한 서버 URL 정보를 OpenAPI 스펙에 명시
- 컨트롤러 Swagger 태그 및 요약 정보 추가
  - AuthController
    - `@Tag(name = "Auth", description = "인증/인가 관련 API")` 적용
    - `/auth/login`, `/auth/me`, `/auth/refresh` 엔드포인트에 `@Operation(summary = "...")`로 역할 명시
  - UserController
    - 사용자 관련 엔드포인트에 태그 및 `@Operation` 요약 추가 (사용자 정보 조회 등)
  - ReportController
    - `@Tag(name = "Report", description = "게시글 및 댓글 신고 API")` 적용
    - 게시글/댓글 신고 엔드포인트에 `@Operation(summary = "게시글 신고" / "댓글 신고")` 추가
  - MemoController
    - `@Tag(name = "Memo", description = "완전 익명 메모 API")` 적용
    - 메모 조회/작성 API에 `@Operation`과 `@Parameter`로 파라미터 설명(all 옵션 등) 추가
- SecurityConfig 정리
  - SecurityConfig 패키지를 `global.security.config`로 이동하여 보안 관련 설정을 한 곳에 집약
  - Swagger/OpenAPI 경로를 익명 허용
    - `/v3/api-docs/**`
    - `/swagger-ui/**`
    - `/swagger-ui.html`
  - 기존 Auth, Memo 등 익명 허용 엔드포인트와 함께 예외 경로를 한 SecurityConfig에서 일괄 관리

## 구성된 파일
- build.gradle (springdoc-openapi 의존성 추가)
- src/main/java/com/gdg/slbackend/global/config/OpenApiConfig.java
- src/main/java/com/gdg/slbackend/global/config/SecurityConfig.java (Swagger 경로 permitAll 및 패키지 이동)
- src/main/java/com/gdg/slbackend/api/auth/AuthController.java
- src/main/java/com/gdg/slbackend/api/user/UserController.java
- src/main/java/com/gdg/slbackend/api/report/ReportController.java
- src/main/java/com/gdg/slbackend/api/memo/MemoController.java (Swagger 태그/Operation/Parameter 추가)

## 구현 목적
- 프론트엔드 및 외부 소비자가 브라우저에서 바로 API 스펙을 확인할 수 있도록 Swagger UI 제공
- 컨트롤러별 태그 및 요약 정보를 통해 엔드포인트 목적을 일관되게 문서화
- Swagger/OpenAPI와 보안 설정을 `global.security.config` 하위로 모아 유지보수성과 가독성을 향상
- 이후 신규 도메인 추가 시 동일한 방식으로 문서를 확장할 수 있는 기반 마련

## 이후 예정 작업
- 각 API별 응답/에러 스키마에 대한 `@Schema`, `@ApiResponses` 등 상세 문서화
- 인증이 필요한 엔드포인트에 대한 예시 토큰 및 보안 스키마(SecurityScheme) 정의
- Community, Post, Comment 등 나머지 컨트롤러에도 태그/요약/예시 추가
